### PR TITLE
QGIS external applications

### DIFF
--- a/qgis-ext-apps/Dockerfile
+++ b/qgis-ext-apps/Dockerfile
@@ -1,0 +1,19 @@
+FROM geocompr/geocompr:qgis
+
+# run the subsequent line if you are behind a proxy (usually the case when inside OC)
+RUN echo 'Acquire::http::Proxy "http://dcea-ifwebgw01.gfk.com:3128";' >> /etc/apt/apt.conf
+RUN apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests --allow-unauthenticated -y \
+    qgis-plugin-grass \
+    saga
+ENV QT_QPA_PLATFORM='offscreen'
+RUN qgis_process && \
+    echo "[PythonPlugins]\nprocessing=true" >> ~/.local/share/QGIS/QGIS3/profiles/default/QGIS/QGIS3.ini
+# and now do the same for the rstudio user
+USER rstudio
+ENV QT_QPA_PLATFORM='offscreen' 
+RUN qgis_process &&\
+    RUN echo "[PythonPlugins]\nprocessing=true" >> ~/.local/share/QGIS/QGIS3/profiles/default/QGIS/QGIS3.ini
+WORKDIR /home/rstudio/geocompr
+USER root
+# RUN R -e "remotes::install_github('paleolimbot/qgisprocess')"

--- a/qgis-ext-apps/Dockerfile
+++ b/qgis-ext-apps/Dockerfile
@@ -1,5 +1,6 @@
 FROM geocompr/geocompr:qgis
 
+RUN R -e "remotes::install_github('paleolimbot/qgisprocess')"
 RUN apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests --allow-unauthenticated -y \
     qgis-plugin-grass \
@@ -14,4 +15,3 @@ RUN qgis_process &&\
     RUN echo "[PythonPlugins]\nprocessing=true" >> ~/.local/share/QGIS/QGIS3/profiles/default/QGIS/QGIS3.ini
 WORKDIR /home/rstudio/geocompr
 USER root
-# RUN R -e "remotes::install_github('paleolimbot/qgisprocess')"

--- a/qgis-ext-apps/Dockerfile
+++ b/qgis-ext-apps/Dockerfile
@@ -5,10 +5,11 @@ RUN apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests --allow-unauthenticated -y \
     qgis-plugin-grass \
     saga
+# enable all available QGIS geoalgorithms for the root user
 ENV QT_QPA_PLATFORM='offscreen'
 RUN qgis_process && \
     echo "[PythonPlugins]\nprocessing=true" >> ~/.local/share/QGIS/QGIS3/profiles/default/QGIS/QGIS3.ini
-# and now do the same for the rstudio user
+# ... and now do the same for the rstudio user
 USER rstudio
 ENV QT_QPA_PLATFORM='offscreen' 
 RUN qgis_process &&\

--- a/qgis-ext-apps/Dockerfile
+++ b/qgis-ext-apps/Dockerfile
@@ -1,7 +1,5 @@
 FROM geocompr/geocompr:qgis
 
-# run the subsequent line if you are behind a proxy (usually the case when inside OC)
-RUN echo 'Acquire::http::Proxy "http://dcea-ifwebgw01.gfk.com:3128";' >> /etc/apt/apt.conf
 RUN apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests --allow-unauthenticated -y \
     qgis-plugin-grass \

--- a/qgis-ext/Dockerfile
+++ b/qgis-ext/Dockerfile
@@ -12,7 +12,6 @@ RUN qgis_process && \
 # ... and now do the same for the rstudio user
 USER rstudio
 ENV QT_QPA_PLATFORM='offscreen' 
-RUN qgis_process &&\
-    RUN echo "[PythonPlugins]\nprocessing=true" >> ~/.local/share/QGIS/QGIS3/profiles/default/QGIS/QGIS3.ini
-WORKDIR /home/rstudio/geocompr
+RUN qgis_process && \
+    echo "[PythonPlugins]\nprocessing=true" >> ~/.local/share/QGIS/QGIS3/profiles/default/QGIS/QGIS3.ini
 USER root


### PR DESCRIPTION
Hey Robin,
as promised in #4, this is the Dockerfile also installing the external applications (SAGA, GRASS). I think the name qgis-ext-apps is generic enough because this way we could also include further supported external applications supported by QGIS (e.g., LiDAR tools and OTB) if we chose so. However, I really don't mind if you prefer the tags qgis-plus or qgis-+, let me know, and I change the tag accordingly.
I have not tested everything so far, but in general it should work. I will test tonight if the `WORKDIR` command in fact jumps into the geocompr folder when running rocker - something we have already tried to achieve quite some time ago. But maybe it does, since we are explicitly changing the user. At least, this worked for adjusting the QGIS3.ini file (already tested).
